### PR TITLE
Creative Gate Teleport using Custom Events

### DIFF
--- a/src/com/massivecraft/creativegates/P.java
+++ b/src/com/massivecraft/creativegates/P.java
@@ -19,6 +19,7 @@ public class P extends JavaPlugin {
 	public PluginBlockListener blockListener;
 	public PluginBlockListenerMonitor blockListenerMonitor;
 	public PluginEntityListener entityListener;
+	public PluginGateListener gateListener;
 	
 	public P() {
 		p = this;
@@ -27,6 +28,7 @@ public class P extends JavaPlugin {
 		this.blockListener = new PluginBlockListener(this);
 		this.blockListenerMonitor = new PluginBlockListenerMonitor(this);
 		this.entityListener = new PluginEntityListener(this);
+		this.gateListener = new PluginGateListener(this);
 	}
 
 	public void onEnable() {
@@ -53,6 +55,8 @@ public class P extends JavaPlugin {
 		pm.registerEvent(Event.Type.BLOCK_BREAK, this.blockListenerMonitor, Event.Priority.Monitor, this);
 		
 		pm.registerEvent(Event.Type.ENTITY_EXPLODE, this.entityListener, Event.Priority.Normal, this);
+		
+		pm.registerEvent(Event.Type.CUSTOM_EVENT, this.gateListener, Event.Priority.Monitor, this);
 		
 		log("===== ENABLE END");
 	}

--- a/src/com/massivecraft/creativegates/event/CreativeGatesListener.java
+++ b/src/com/massivecraft/creativegates/event/CreativeGatesListener.java
@@ -1,0 +1,17 @@
+package com.massivecraft.creativegates.event;
+
+import org.bukkit.event.CustomEventListener;
+import org.bukkit.event.Event;
+
+
+public class CreativeGatesListener extends CustomEventListener {
+    @Override
+    public void onCustomEvent(Event event) {
+        if(event instanceof CreativeGatesTeleportEvent) {
+            onPlayerGateTeleport((CreativeGatesTeleportEvent) event);
+        }
+        super.onCustomEvent(event);
+    }
+    
+    public void onPlayerGateTeleport(CreativeGatesTeleportEvent event) { }
+}

--- a/src/com/massivecraft/creativegates/event/CreativeGatesTeleportEvent.java
+++ b/src/com/massivecraft/creativegates/event/CreativeGatesTeleportEvent.java
@@ -1,0 +1,50 @@
+package com.massivecraft.creativegates.event;
+
+import java.util.Set;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+@SuppressWarnings("serial")
+public class CreativeGatesTeleportEvent extends Event implements Cancellable {
+    
+    private Location location;
+    private Set<Material> materials;
+    private boolean cancelled;
+    private PlayerMoveEvent event;
+
+    public CreativeGatesTeleportEvent(PlayerMoveEvent event, Location location, Set<Material> materials) {
+        super("CreativeGatesTeleportEvent");
+        this.event = event;
+        this.location = location;
+        this.materials = materials;
+        this.cancelled = false;
+    }
+    
+    public boolean isCancelled(){
+        return this.cancelled;
+    }
+    
+    public void setCancelled(boolean cancelled){
+        this.cancelled = cancelled;
+    }
+    
+    public Location getLocation() {
+        return this.location;
+    }
+    
+    public void setLocation(Location location) {
+        this.location = location;
+    }
+    
+    public Set<Material> getMaterials() {
+        return this.materials;
+    }
+    
+    public PlayerMoveEvent getPlayerMoveEvent() {
+        return this.event;
+    }
+}

--- a/src/com/massivecraft/creativegates/listeners/PluginGateListener.java
+++ b/src/com/massivecraft/creativegates/listeners/PluginGateListener.java
@@ -1,0 +1,28 @@
+package com.massivecraft.creativegates.listeners;
+
+import org.bukkit.entity.Player;
+
+import com.massivecraft.creativegates.P;
+import com.massivecraft.creativegates.event.CreativeGatesListener;
+import com.massivecraft.creativegates.event.CreativeGatesTeleportEvent;
+
+public class PluginGateListener extends CreativeGatesListener {
+    public PluginGateListener(P plugin) {
+    }
+    @Override
+    public void onPlayerGateTeleport(CreativeGatesTeleportEvent event) {
+        if(event.isCancelled()) return;
+        // Teleport
+        Player player = event.getPlayerMoveEvent().getPlayer();
+        
+        // For now we do not handle vehicles
+        if (player.isInsideVehicle()) {
+            player.leaveVehicle();
+        }
+        
+        player.setNoDamageTicks(5);
+        event.getPlayerMoveEvent().setFrom(event.getLocation());
+        event.getPlayerMoveEvent().setTo(event.getLocation());
+        player.teleport(event.getLocation());
+    }
+}

--- a/src/com/massivecraft/creativegates/listeners/PluginPlayerListener.java
+++ b/src/com/massivecraft/creativegates/listeners/PluginPlayerListener.java
@@ -1,5 +1,7 @@
 package com.massivecraft.creativegates.listeners;
 
+import java.util.HashSet;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.*;
@@ -17,6 +19,7 @@ import com.massivecraft.creativegates.Gates;
 import com.massivecraft.creativegates.P;
 import com.massivecraft.creativegates.Permission;
 import com.massivecraft.creativegates.WorldCoord;
+import com.massivecraft.creativegates.event.CreativeGatesTeleportEvent;
 
 
 
@@ -57,18 +60,13 @@ public class PluginPlayerListener extends PlayerListener {
 			return;
 		}
 		
-		// Teleport
-		Player player = event.getPlayer();
-		
-		// For now we do not handle vehicles
-		if (player.isInsideVehicle()) {
-			player.leaveVehicle();
+		HashSet<Material> frameMaterials = new HashSet<Material>();
+		for(int id : gateFrom.frameMaterialIds) {
+		    frameMaterials.add(Material.getMaterial(id));
 		}
 		
-		player.setNoDamageTicks(5);
-		event.setFrom(targetLocation);
-        event.setTo(targetLocation);
-        player.teleport(targetLocation);
+		CreativeGatesTeleportEvent gateevent = new CreativeGatesTeleportEvent(event, targetLocation, frameMaterials);
+		this.p.getServer().getPluginManager().callEvent(gateevent);
 	}
 	
 	public void onPlayerInteract(PlayerInteractEvent event) {


### PR DESCRIPTION
Changed gate teleport to use a new custom event instead of performing the teleport directly from the onPlayerMove event.
