### PR TITLE
MPlugin.java has a onDisable() to ensure all gates are saved when the ser

### DIFF
--- a/src/com/massivecraft/creativegates/CreativeGates.java
+++ b/src/com/massivecraft/creativegates/CreativeGates.java
@@ -61,6 +61,8 @@ public class CreativeGates extends MPlugin
 	
 	public void onDisable()
 	{
+		super.onDisable(); //Ensure all gates are saved when stopping the server.
+
 		Gates.i.emptyAll();
 	}
 	


### PR DESCRIPTION
MPlugin.java has a onDisable() to ensure all gates are saved when the server/plugin is stopped/disabled, but it is never called from it's overridden method.

[Coppied from forum post]
You override onDisable() in (CreativeGates [extends MPlugin]) but you never call the base onDisable() so gates are never saved outside of the timer. (The code is there; it's just never called.)

Add super.onDisable(); to the overridden onDisable() in CreativeGates.java
